### PR TITLE
Bug / Crash fix

### DIFF
--- a/Classes/NetworkWebSocket.cpp
+++ b/Classes/NetworkWebSocket.cpp
@@ -125,7 +125,7 @@ void NetworkWebSocket::onOpen(network::WebSocket * ws)
 void NetworkWebSocket::onMessage(network::WebSocket * ws, const network::WebSocket::Data & data)
 {
 	if(_onMessageReceivedCallBack != nullptr)
-		_onMessageReceivedCallBack(data.bytes);
+		_onMessageReceivedCallBack(std::string(data.bytes, data.len));
 }
 
 void NetworkWebSocket::onClose(network::WebSocket * ws)


### PR DESCRIPTION
data.bytes are not null terminated so you should always create string with length argument.